### PR TITLE
Remove top line on Tabs on iOS

### DIFF
--- a/src/components/Tabs/Tabs.scss
+++ b/src/components/Tabs/Tabs.scss
@@ -1,6 +1,8 @@
 @use '../../utilities/colors' as v;
 
 .tabs {
+  position: relative;
+  top: -1px;
   width: 100%;
   display: flex;
   .tab {


### PR DESCRIPTION
- Remove top light line on Tabs on iOS