### PR TITLE
Add related user to activity, add SETTLE action, adjust PayUp logic

### DIFF
--- a/src/components/Activity/Activity.js
+++ b/src/components/Activity/Activity.js
@@ -5,12 +5,18 @@ import { useGetExpenseQuery } from '../../slices/expenseSlice';
 import { useGetDebtQuery } from '../../slices/debtSlice';
 import Avatar from '../Avatar/Avatar';
 
-const Activity = ({ userId, referenceId, type, action, date }) => {
+const Activity = ({ userId, referenceId, type, action, date, relatedUserId = null }) => {
   const user = useSelector(state => state.auth.user);
   const {
     data: account,
     isSuccess: accountFetched
   } = useGetAccountQuery(userId);
+  const {
+    data: relatedAccount,
+    isSuccess: relatedAccountFetched
+  } = useGetAccountQuery(relatedUserId, {
+    skip: !relatedUserId
+  });
   const currentUser = user?.id === userId;
 
   const {
@@ -53,8 +59,29 @@ const Activity = ({ userId, referenceId, type, action, date }) => {
               {action === 'CREATE' && 'created'}
               {action === 'UPDATE' && `updated a${type === 'EXPENSE' && 'n'}`}
               {action === 'DELETE' && `deleted a${type === 'EXPENSE' && 'n'}`}
-              {action === 'PAY' && 'paid a'}
-              {` ${type?.toLowerCase()}`}
+              {action === 'PAY' ? (
+                <div className="activity__pay">
+                  <span className="activity__pay-text">paid{' '}</span>
+                  {relatedAccountFetched ? (
+                  <span className="activity__name">
+                    {relatedAccount?.name}
+                  </span>) : type?.toLowerCase()}
+                </div>
+              ) : null}
+              {action === 'SETTLE' ? (
+                <div className="activity__pay">
+                  <span className="activity__pay-text">settled{' '}
+                    {relatedAccountFetched ? (
+                      <>
+                        <span>with{' '}</span>
+                        <span className="activity__name">
+                          {relatedAccount?.name}
+                        </span>
+                      </>) : type?.toLowerCase()}
+                  </span>
+                </div>
+              ) : null}
+              {action !== 'PAY' && action !== 'SETTLE' && ` ${type?.toLowerCase()}`}
             </span>
           </div>
         </div>

--- a/src/components/Activity/Activity.scss
+++ b/src/components/Activity/Activity.scss
@@ -34,12 +34,16 @@
 }
 
 .activity__text {
+  display: inline-block;
   color: v.$almost-black;
   font-size: 0.875rem;
   line-height: 1.063rem;
   padding: 0.5rem 0.5rem 0.5rem 0;
   .activity__name {
     font-weight: 600;
+  }
+  .activity__pay {
+    display: inline-block;
   }
 }
 

--- a/src/pages/Activities/Activities.js
+++ b/src/pages/Activities/Activities.js
@@ -42,6 +42,7 @@ const Activities = () => {
                   type={activity?.type}
                   action={activity?.action}
                   date={activity?.created_at}
+                  relatedUserId={activity?.related_user_id}
                 />
               )
             }) : null}

--- a/src/pages/Expense/Expense.js
+++ b/src/pages/Expense/Expense.js
@@ -177,7 +177,8 @@ const Expense = () => {
                         referenceId={activity?.reference_id}
                         type={activity?.type}
                         action={activity?.action}
-                        date={activity?.created_at} />
+                        date={activity?.created_at}
+                        relatedUserId={activity?.related_user_id} />
                     ))}
                   </div>
                 </div>) : null}

--- a/src/pages/Expense/Expense.scss
+++ b/src/pages/Expense/Expense.scss
@@ -22,6 +22,9 @@
     }
     .details__info-text {
       gap: 0.5rem;
+      .details__title {
+        text-align: center;
+      }
     }
   }
 }

--- a/src/pages/Profile/Profile.js
+++ b/src/pages/Profile/Profile.js
@@ -10,8 +10,8 @@ import DetailsCard from '../../components/DetailsCard/DetailsCard';
 import FriendAction from '../FriendAction/FriendAction';
 import Transactions from '../../components/Transactions/Transactions';
 import Balances from '../../components/Balances/Balances';
-import { useGetDebtsQuery, selectSharedDebtsByFriendId } from '../../slices/debtSlice';
-import { useGetExpensesQuery, selectSharedExpensesByDebt } from '../../slices/expenseSlice';
+import { useGetDebtsQuery, selectUnpaidSharedDebtsByFriendId } from '../../slices/debtSlice';
+import { useGetExpensesQuery, selectUnpaidSharedExpensesByDebt } from '../../slices/expenseSlice';
 import { useGetAccountQuery } from '../../slices/accountSlice';
 import { balanceCalc } from '../../helpers/balance';
 
@@ -30,7 +30,7 @@ const Profile = () => {
     isSuccess: debtsFetched } = useGetDebtsQuery(user?.id, {
     selectFromResult: (result) => ({
       ...result,
-      sharedDebts: selectSharedDebtsByFriendId(result, id)
+      sharedDebts: selectUnpaidSharedDebtsByFriendId(result, id)
     })
   });
 
@@ -38,13 +38,15 @@ const Profile = () => {
     skip: !debtsFetched,
     selectFromResult: (result) => ({
       ...result,
-      currentExpenses: selectSharedExpensesByDebt(result, sharedDebts)
+      currentExpenses: selectUnpaidSharedExpensesByDebt(result, sharedDebts)
     })
   })
 
   useEffect(() => {
-    setBalances(balanceCalc(sharedDebts, user.id));
-  }, [sharedDebts, user]);
+    if(debtsFetched) {
+      setBalances(balanceCalc(sharedDebts, user.id));
+    }
+  }, [sharedDebts, debtsFetched, user]);
 
   return (
     <>

--- a/src/slices/activityApi.js
+++ b/src/slices/activityApi.js
@@ -8,7 +8,7 @@ export const extendedSupabaseApi = supabaseApi.injectEndpoints({
         const { data, error } = await supabase
           .from('activity')
           .select()
-          .eq('user_id', userId);
+          .or(`user_id.eq.${userId},related_user_id.eq.${userId}`);
         return { data, error };
       },
       providesTags: (result = [], error, arg) => [

--- a/src/slices/debtSlice.js
+++ b/src/slices/debtSlice.js
@@ -114,6 +114,11 @@ export const selectSharedDebtsByFriendId = createSelector(
   (data, friendId) => data?.filter(debt => (debt.creditor_id === friendId || debt.debtor_id === friendId)) ?? []
 );
 
+export const selectUnpaidSharedDebtsByFriendId = createSelector(
+  res => res.data, (data, friendId) => friendId,
+  (data, friendId) => data?.filter(debt => (debt.creditor_id === friendId || debt.debtor_id === friendId) && debt.paid === false) ?? []
+);
+
 export const selectUserDebtsByGroupId = createSelector(
   res => res.data, (data, groupId) => groupId,
   (data, groupId) => data?.filter(debt =>

--- a/src/slices/expenseSlice.js
+++ b/src/slices/expenseSlice.js
@@ -93,6 +93,13 @@ export const selectSharedExpensesByDebt = createSelector(
   ) ?? []
 )
 
+export const selectUnpaidSharedExpensesByDebt = createSelector(
+  res => res.data, (data, sharedDebts) => sharedDebts,
+  (data, sharedDebts) => data?.filter(expense =>
+    sharedDebts.find(shared => shared.expense_id === expense.id && !shared.paid)
+  ) ?? []
+)
+
 export const selectUnpaidExpenses = createSelector(
   res => res.data,
   (data) => data?.filter(expense => !expense.paid) ?? []


### PR DESCRIPTION
- Add related_user_id to activity
- Adjust activities to show related user
- Added SETTLE action for when a user settles a payment
- Adjust PayUp logic to include SETTLE and set expense to paid when all its debts are paid off