### PR TITLE
Fix page overflow

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -101,7 +101,7 @@ section {
 }
 html,
 #root {
-  height: 100vh;
+  min-height: 100vh;
   width: 100vw;
   overscroll-behavior: none;
 }
@@ -134,6 +134,7 @@ button {
 .layout {
   padding-top: calc(46px + env(safe-area-inset-top));
   padding-bottom: calc(46px + env(safe-area-inset-bottom));
+  min-height: 100vh;
   overflow: auto;
 }
 

--- a/src/App.scss
+++ b/src/App.scss
@@ -134,6 +134,7 @@ button {
 .layout {
   padding-top: calc(46px + env(safe-area-inset-top));
   padding-bottom: calc(46px + env(safe-area-inset-bottom));
+  overflow: auto;
 }
 
 .empty-layout {

--- a/src/pages/Activities/Activities.scss
+++ b/src/pages/Activities/Activities.scss
@@ -3,13 +3,13 @@
 .activities-container {
   background: v.$light-gray;
   padding-top: 0.875rem;
-  height: calc(
-    100vh - 46px + env(safe-area-inset-top) + env(safe-area-inset-bottom)
-  );
+}
+
+.layout:has(.activities-container) {
+  background: v.$light-gray;
 }
 
 .activities {
-  height: 100%;
   margin: 0 20px;
   padding: 1.25rem 1rem;
   display: flex;

--- a/src/pages/Dashboard/Dashboard.js
+++ b/src/pages/Dashboard/Dashboard.js
@@ -69,6 +69,7 @@ const Dashboard = () => {
         <>
           <Refresh onRefresh={onRefresh} />
           <div className="dashboard">
+            <div className="details-background"></div>
             <div className="details-container">
               <div className="balance">
                 <div className="balance-block balance-block--total">
@@ -91,7 +92,6 @@ const Dashboard = () => {
                 </div>
               </div>
             </div>
-            <div className="divider"></div>
             <div className="transactions-container">
               <h2 className="main-heading">Recent Transactions</h2>
               {(expensesFetched && unpaidFriendExpenses.length > 0) && <Transactions transactions={unpaidFriendExpenses} />}

--- a/src/pages/Dashboard/Dashboard.scss
+++ b/src/pages/Dashboard/Dashboard.scss
@@ -19,16 +19,17 @@ h2 {
     ),
     v.$layout-green;
 }
-
-.layout:has(.dashboard) {
-  height: 100%;
+.details-background {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  padding-top: env(safe-area-inset-top);
+  height: 240px;
+  object-fit: cover;
+  object-position: center;
+  z-index: -1;
   background: v.$layout-green;
-}
-
-.divider {
-  background: v.$light-gray;
-  height: 86px;
-  margin-top: -62px;
 }
 
 .dashboard {
@@ -37,13 +38,15 @@ h2 {
   height: calc(
     100% + 96px + env(safe-area-inset-top) + env(safe-area-inset-bottom)
   );
-  margin-bottom: 96px;
-  background: #ffffff;
+  background: v.$light-gray;
+}
+
+.refresh-container {
+  background: v.$layout-green;
 }
 
 .transactions-container {
   background: #ffffff;
-  margin-top: -1.5rem;
   padding: 1.5rem 0;
   border-radius: 1rem 1rem 0px 0px;
   flex-grow: 1;
@@ -76,7 +79,7 @@ h2 {
   z-index: 2;
   display: flex;
   min-height: 76px;
-  border-radius: 0.5rem;
+  border-radius: 1rem;
   color: #ffffff;
   filter: drop-shadow(0px 4px 10px rgba(0, 0, 0, 0.15));
 
@@ -87,17 +90,17 @@ h2 {
   }
 
   .balance-block--green {
-    border-radius: 0.5rem 0 0 0.5rem;
+    border-radius: 1rem 0 0 1rem;
   }
   .balance-block--red {
-    border-radius: 0 0.5rem 0.5rem 0;
+    border-radius: 0 1rem 1rem 0;
   }
 
   &::before {
     position: absolute;
     top: 0;
     left: 0;
-    border-radius: 0.5rem;
+    border-radius: 1rem;
     content: '';
     box-shadow: inset 0px -3px 0px rgba(0, 0, 0, 0.25);
     width: 100%;

--- a/src/pages/Expense/Expense.scss
+++ b/src/pages/Expense/Expense.scss
@@ -1,8 +1,11 @@
 @use '../../utilities/colors' as v;
 
+.layout:has(.expense-details-container) {
+  background: v.$light-gray;
+}
+
 .expense-details-container {
   background: v.$light-gray;
-  height: 100vh;
   .details-card {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
- Change `height` to `min-height` in global css file
- Add `overflow: auto` and `min-height` to `layout` CSS class to have Layout span the whole page, but allow the content to overflow past viewport height
- Give `layout` light gray background on `Activity` and `Expense`
- Adjust `Dashboard` styling for consistency, remove divider
- Add `details-background` for refresh pull to have green background